### PR TITLE
Fix incorrectly using mountpoint instead of tmpDir

### DIFF
--- a/archstrap
+++ b/archstrap
@@ -43,7 +43,7 @@ bootstrap_ext() (
     tar -xf "$1" --numeric-owner
 
     [[ -d $2 ]]&& rm -r "$2"
-    mv "$mountpoint/root.x86_64" "$2"
+    mv "$tmpDir/root.x86_64" "$2"
 )
 
 newroot_setup() {


### PR DESCRIPTION
The `root.x86_64` directory we just unpacked is in our current directory ($tmpDir) so we shouldn't expect it to be in $mountpoint. This sometimes works with default parameters because the directories happen to be the same, but not always.