### PR TITLE
Download the PGP signature from archlinux.org

### DIFF
--- a/archstrap
+++ b/archstrap
@@ -31,7 +31,8 @@ arch_chroot() {
 bootstrap_ext() (
     cd "$1"|| return
 
-    curl -O "$mirror/iso/latest/$2{,.sig}"
+    curl -O "$mirror/iso/latest/$2"
+    curl -O "https://archlinux.org/iso/latest/$2.sig"
     gpg --keyserver-options auto-key-retrieve --verify "$2.sig"
 
     tar -xf "$2" --numeric-owner


### PR DESCRIPTION
Downloading it from a mirror may not be _safe_.
See https://wiki.archlinux.org/title/Installation_guide#Verify_signature